### PR TITLE
Fix bug of nil pointer when vm with default pod network creating

### DIFF
--- a/pkg/cni/kube-ovn/kubeovn.go
+++ b/pkg/cni/kube-ovn/kubeovn.go
@@ -40,7 +40,7 @@ func MutateVirtualMachineFitKubeOVNFn(virtualMachine *kubevirt.VirtualMachine, p
 
 func getDefaultMultusName(networks []kubevirt.Network) string {
 	for _, network := range networks {
-		if network.Multus != nil && network.Multus.Default || getNetworkName(network.Multus.NetworkName) == CNI_NAME {
+		if network.Multus != nil && network.Multus.Default && getNetworkName(network.Multus.NetworkName) == CNI_NAME {
 			return network.Name
 		}
 	}


### PR DESCRIPTION
The action of adding annotation to vm with kubeovn should not work on vm
with default pod network

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
